### PR TITLE
Add a url decoding type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ lint:
 	echo "megacheck..."
 	megacheck $(GOPACKAGES)
 	echo "golint..."
-	golint $(GOPACKAGES)
+	golint -set_exit_status $(GOPACKAGES) 
 	echo "go vet..."
 	go vet --all $(GOPACKAGES)
 

--- a/checkers/helpers.go
+++ b/checkers/helpers.go
@@ -1,0 +1,36 @@
+package checkers
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+// OK fails the test if an err is not nil.
+func OK(tb testing.TB, err error) {
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: unexpected error: %s\033[39m\n\n", filepath.Base(file), line, err.Error())
+		tb.FailNow()
+	}
+}
+
+// Equals fails the test if got is not equal to want.
+func Equals(tb testing.TB, got, want interface{}) {
+	if !reflect.DeepEqual(got, want) {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\tgot: %#v\n\n\twant: %#v\033[39m\n\n", filepath.Base(file), line, got, want)
+		tb.FailNow()
+	}
+}
+
+// Assert fails the test if the condition is false.
+func Assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
+	if !condition {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
+		tb.FailNow()
+	}
+}

--- a/encoding/url.go
+++ b/encoding/url.go
@@ -1,0 +1,88 @@
+// Package encoding implements base64 decoding of signed urls for insecure
+// asset proxying.
+// Copyright (c) 2012-2016 Eli Janssen
+// Copyright (c) 2017 Berkeley Electronic Press
+// Copyright (c) 2017 Reed O'Brien reed@reedobrien.com
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+package encoding
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+)
+
+// Decoder is an interface that signs and encodes or verifies and decodes URLs
+// for camo consumption.
+type Decoder interface {
+	Decode(string, string) (string, error)
+}
+
+// MustNewURLDecoder returns a new UrlDecoder or panics.
+func MustNewURLDecoder(hmackey []byte) URLDecoder {
+	if len(hmackey) == 0 {
+		panic("empty hmac not allowed")
+	}
+	return URLDecoder{hmackey: hmackey}
+}
+
+// URLDecoder implements Decoder.
+type URLDecoder struct {
+	hmackey []byte
+}
+
+// Decode verifies the signature (digest) against the decoded url.  It ensures
+// the url is properly verified via HMAC, and then decodes the url, returning
+// the url (if valid) or an error.
+func (ed URLDecoder) Decode(dig, url string) (string, error) {
+	var (
+		ub  []byte
+		err error
+	)
+
+	ub, err = ed.b64DecodeURL(dig, url)
+
+	if err != nil {
+		return "", err
+	}
+	return string(ub), nil
+}
+
+func (ed URLDecoder) validateURL(macbytes []byte, urlbytes []byte) error {
+	mac := hmac.New(sha1.New, ed.hmackey)
+	mac.Write(urlbytes)
+	macSum := mac.Sum(nil)
+
+	// ensure lengths are equal. if not, return error.
+	if len(macSum) != len(macbytes) {
+		return fmt.Errorf("mismatched length")
+	}
+
+	if subtle.ConstantTimeCompare(macSum, macbytes) != 1 {
+		return fmt.Errorf("invalid mac")
+	}
+	return nil
+}
+
+// b64DecodeURL ensures the url is properly verified via HMAC, and then
+// decodes the url, returning the url (if valid) or an error.
+func (ed URLDecoder) b64DecodeURL(encdig string, encURL string) ([]byte, error) {
+	urlBytes, err := base64.RawURLEncoding.DecodeString(encURL)
+	if err != nil {
+		return nil, fmt.Errorf("bad url decode")
+	}
+
+	macBytes, err := base64.RawURLEncoding.DecodeString(encdig)
+	if err != nil {
+		return nil, fmt.Errorf("bad mac decode")
+	}
+
+	if err := ed.validateURL(macBytes, urlBytes); err != nil {
+		return nil, fmt.Errorf("invalid signature: %s", err)
+	}
+
+	return urlBytes, nil
+}

--- a/encoding/url_test.go
+++ b/encoding/url_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2012-2016 Eli Janssen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package encoding_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bepress/camo/checkers"
+	"github.com/bepress/camo/encoding"
+)
+
+func TestMustNewURLDecoderPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("MustNewURLDecoder failed to panic")
+		}
+	}()
+
+	_ = encoding.MustNewURLDecoder(nil)
+}
+
+func TestDecodeURLs(t *testing.T) {
+	table := []struct {
+		desc    string
+		errStr  string
+		in      string
+		want    string
+		wantErr bool
+		hmackey string
+	}{
+		{"test success host only url", "", "/I2s_jHIbZkwmHHX8wb8hmdxDM1g/aHR0cDovL2JlcHJlc3MuY29t", "http://bepress.com", false, "test"},
+		{"test failing host url", "invalid signature: invalid mac", "/I2s_jHIbZkwmHHX8wb8hmdxDM1g/aH0cDovL2JlcHJlc3MuY29t", "", true, "test"},
+		{"test failing host digest", "invalid signature: mismatched length", "/I2s_jHIbZkwmHHX8wb8hmdxDM1/aHR0cDovL2JlcHJlc3MuY29t", "", true, "test"},
+		{"test failing hmackey ", "invalid signature: invalid mac", "/I2s_jHIbZkwmHHX8wb8hmdxDM1g/aHR0cDovL2JlcHJlc3MuY29t", "", true, "wrong"},
+		{"test failing url encoding", "bad url decode", "/I2s_jHIbZkwmHHX8wb8hmdxDM1g/aHR0/cDovL2JlcHJlc3MuY29t", "", true, "wrong"},
+		{"test failing url encoding", "bad mac decode", "/I2s_jHI=bZkwmHHX8wb8hmdxDM1g/aHR0cDovL2JlcHJlc3MuY29t", "", true, "wrong"},
+	}
+
+	for _, test := range table {
+		tut := encoding.MustNewURLDecoder([]byte(test.hmackey))
+		dig, url := serverSplitURL(test.in)
+		got, err := tut.Decode(dig, url)
+		if test.wantErr {
+			checkers.Equals(t, err.Error(), test.errStr)
+			continue
+		}
+		checkers.OK(t, err)
+		checkers.Equals(t, got, test.want)
+	}
+}
+
+func serverSplitURL(s string) (string, string) {
+	parts := strings.SplitN(s, "/", 3)
+	return parts[1], parts[2]
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ func main() {
 	fmt.Println(Hello())
 }
 
+// Hello is a place holder
 func Hello() string {
 	return "vim-go"
 


### PR DESCRIPTION
This adds a type which can decode base64 encoded urls which are created
in digital commons using a magic template macro.

The decoded url is then used in the server to proxy the asset.

Refs: https://bepress.atlassian.net/browse/BP-5064