### PR TITLE
Add health check endpoint

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -127,6 +127,12 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Split path and get components.
 	sig, encodedURL, err := p.splitComponents(r.URL.Path)
 	if err != nil {
+		// If it is not a valid signed URL, it may be a health check for the
+		// ELB. Handle that here.
+		if r.URL.Path == "/health" {
+			fmt.Fprintln(w, "OK")
+			return
+		}
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -15,6 +15,22 @@ import (
 	"github.com/rs/zerolog"
 )
 
+func TestProxyHealth(t *testing.T) {
+	tut := proxy.MustNew([]byte("test"),
+		zerolog.New(ioutil.Discard))
+	ts := httptest.NewTLSServer(tut)
+	client := ts.Client()
+	got, err := client.Get(ts.URL + "/health")
+	checkers.OK(t, err)
+
+	checkers.Equals(t, got.StatusCode, http.StatusOK)
+	body, err := ioutil.ReadAll(got.Body)
+	checkers.OK(t, err)
+	got.Body.Close()
+	checkers.Equals(t, string(body), "OK\n")
+
+}
+
 func TestProxyPanicsNilKey(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {


### PR DESCRIPTION
We return 200 OK to anything asking for GET or HEAD /health.
Refs: https://bepress.atlassian.net/browse/BP-5064