### PR TITLE
Make camo environment configurable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,12 +72,11 @@ workflows:
           type: approval
           filters:
             tags:
-              only: /.*/
+              only: /^20.*/
+            branches:
+              ignore: /.*/
           requires:
             - build
       - release:
           requires:
             - hold
-          filters:
-            tags:
-              only: /.*/

--- a/_misc/camo.service
+++ b/_misc/camo.service
@@ -2,6 +2,7 @@
 Description=TLS asset proxy for non TLS assets
 ConditionPathExists=/usr/local/bin/camo
 After=network.target
+EnvironmentFile=/var/camo/env
 
 [Service]
 Type=simple


### PR DESCRIPTION
We want to set the AWS_REGION for the camo service, but we might want to have more environment varibles in the future as well. If we tell systemd to read from an EnvironmentFile we can modify the deployment process in the future to populate that environment file with AWS_REGION and any other environment variables we need.