### PR TITLE
Feature/moar logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ARCH            := $(shell go env GOARCH)
 
 GITHASH         :=$(shell git rev-parse --short HEAD)
 GITBRANCH       :=$(shell git rev-parse --abbrev-ref HEAD)
-GITTAGORBRANCH 	:=$(shell sh -c 'git describe --always --dirty --tags 2>/dev/null')
+GITTAGORBRANCH 	:=$(shell sh -c 'git describe --always --dirty 2>/dev/null')
 BUILDDATE      	:=$(shell date -u +%Y%m%d%H%M)
 GO_LDFLAGS		?= -s -w
 GO_BUILD_FLAGS  :=-ldflags "${GOLDFLAGS} -X main.BuildVersion=${GITTAGORBRANCH} -X main.GitHash=${GITHASH} -X main.GitBranch=${GITBRANCH} -X main.BuildDate=${BUILDDATE}"

--- a/logging/access.go
+++ b/logging/access.go
@@ -68,6 +68,7 @@ func (ar *byteCounter) WriteHeader(status int) {
 
 // NewAccessLogger returns a constructed AccessLogger pointer.
 func NewAccessLogger(handler http.Handler, logger zerolog.Logger) http.Handler {
+	logger = logger.With().Str("type", "access").Logger()
 	return &AccessLogger{
 		handler: handler,
 		logger:  logger,


### PR DESCRIPTION
- Don't use non annotated tags when describing the tag/commit. 
- Add more logging for statistical information regarding proxied content and add "access" type to the access logs should we want to farm that info later.
