### PR TITLE
Return 400 for bad redirect

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -103,7 +103,7 @@ func TestRedirectFilters(t *testing.T) {
 		checkers.OK(t, err)
 
 		err = tut.RedirFunc(req, []*http.Request{})
-		checkers.Equals(t, err.Error(), fmt.Sprintf("filtered host address: %q", test.hostIP))
+		checkers.Equals(t, err.Error(), fmt.Sprintf("invalid redirect: filtered host address: %q", test.hostIP))
 	}
 
 }


### PR DESCRIPTION
We are currently returing a 500 when we encounter a bad redirect
but to be consistent we should raise a 400.

Fixes #45